### PR TITLE
fix: When soft deleting an entity, the program crashes due to a vm te…

### DIFF
--- a/smart-admin-api/sa-base/src/main/resources/code-generator-template/java/dao/Dao.java.vm
+++ b/smart-admin-api/sa-base/src/main/resources/code-generator-template/java/dao/Dao.java.vm
@@ -37,14 +37,14 @@ public interface ${name.upperCamel}Dao extends BaseMapper<${name.upperCamel}Enti
     /**
      * 更新删除状态
      */
-    long updateDeleted(@Param("${primaryKeyFieldName}")${primaryKeyJavaType} ${primaryKeyFieldName},@Param("${deletedFlag}")boolean deletedFlag);
+    long updateDeleted(@Param("${primaryKeyFieldName}")${primaryKeyJavaType} ${primaryKeyFieldName},@Param("deletedFlag")boolean deletedFlag);
 
 #end
 #if($deleteInfo.deleteEnum == "Batch" || $deleteInfo.deleteEnum == "SingleAndBatch")
     /**
      * 批量更新删除状态
      */
-    void batchUpdateDeleted(@Param("idList")List<${primaryKeyJavaType}> idList,@Param("${deletedFlag}")boolean deletedFlag);
+    void batchUpdateDeleted(@Param("idList")List<${primaryKeyJavaType}> idList,@Param("deletedFlag")boolean deletedFlag);
 
 #end
 #end


### PR DESCRIPTION
…mplate error.

When soft deleting an entity, the program crashes due to a vm template error.
```
Caused by: org.apache.ibatis.binding.BindingException: Parameter 'deletedFlag' not found. Available parameters are [materialSupplyId, ${deletedFlag}, param1, param2]
```

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/b62f741e-6ce1-4403-93fd-0f60bf99fe39">

