### PR TITLE
修改因为dayjs 版本导致的日期选择报错、本地化显示问题

### DIFF
--- a/smart-admin-web-typescript/package.json
+++ b/smart-admin-web-typescript/package.json
@@ -24,7 +24,7 @@
     "axios": "1.6.8",
     "clipboard": "2.0.11",
     "crypto-js": "4.1.1",
-    "dayjs": "1.10.5",
+    "dayjs": "1.11.13",
     "decimal.js": "10.3.1",
     "default-passive-events": "^2.0.0",
     "diff": "5.2.0",


### PR DESCRIPTION
使用 `smart-admin-web-typescript` 时，安装完依赖，使用日期范围选择框的月份语言是英文，选择左侧的预制时间范围直接报错

```ts
ant-design-vue.js?v=5efdcd9b:33159 Uncaught (in promise) TypeError: clone3.weekday is not a function
    at Object.getWeekDay (ant-design-vue.js?v=5efdcd9b:33159:19)
    at getWeekStartDate (ant-design-vue.js?v=5efdcd9b:33847:44)
    at DateBody (ant-design-vue.js?v=5efdcd9b:34501:20)
    at renderComponentRoot (chunk-THN6NHUB.js?v=5efdcd9b:2521:13)
```
通过排查发现是项目使用的dayjs版本和ant design vue 使用的版本不对应导致的