### PR TITLE
修复前端个人中心表单超出背景的问题

### DIFF
--- a/smart-admin-web-javascript/src/views/system/account/components/center/index.vue
+++ b/smart-admin-web-javascript/src/views/system/account/components/center/index.vue
@@ -233,13 +233,21 @@
   });
 </script>
 <style lang="less" scoped>
-  .center-container {
+.center-container {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    
     .header-title {
       font-size: 20px;
+      flex-shrink: 0;
     }
 
     .center-form-area {
       margin-top: 20px;
+      flex: 1;
+      overflow-y: auto;
+      min-height: 0;
 
       .avatar-container {
         position: relative;


### PR DESCRIPTION
修复方案：
在 /views/system/account/components/center/index.vue 中： 设置容器高度为100%并使用flex布局
标题区域使用 flex-shrink: 0 防止压缩
表单区域使用 flex: 1 占据剩余空间
添加 overflow-y: auto 支持垂直滚动
设置 min-height: 0 确保正确的高度计算