### PR TITLE
Update spin.js

### DIFF
--- a/smart-admin-web-javascript/src/store/modules/system/spin.js
+++ b/smart-admin-web-javascript/src/store/modules/system/spin.js
@@ -18,13 +18,27 @@ export const useSpinStore = defineStore({
   actions: {
     hide() {
       this.loading = false;
-      let spins = document.querySelector('.ant-spin-nested-loading');
-      spins.style.zIndex = 999;
+      // 安全的DOM操作，避免null引用错误
+      try {
+        const spins = document.querySelector('.ant-spin-nested-loading');
+        if (spins) {
+          spins.style.zIndex = '999';
+        }
+      } catch (error) {
+        console.warn('Spin hide操作失败:', error);
+      }
     },
     show() {
       this.loading = true;
-      let spins = document.querySelector('.ant-spin-nested-loading');
-      spins.style.zIndex = 1001;
+      // 安全的DOM操作，避免null引用错误
+      try {
+        const spins = document.querySelector('.ant-spin-nested-loading');
+        if (spins) {
+          spins.style.zIndex = '1001';
+        }
+      } catch (error) {
+        console.warn('Spin show操作失败:', error);
+      }
     },
   },
 });


### PR DESCRIPTION
修复菜单切换卡死问题;
为 useSpinStore 的DOM操作添加安全检查，使用 try-catch 包装DOM操作，添加 null 检查，避免访问不存在的DOM元素